### PR TITLE
fix: argument parsing with quotes

### DIFF
--- a/transform.js
+++ b/transform.js
@@ -4,7 +4,7 @@ function run(argv) {
   const input = argv[0];
 
   const WORD = /[a-zA-Z0-9а-яёєґїА-ЯЁЄҐЇ]+/g;
-  const ARGUMENT = /(?:'([^'"]*)'|"([^'"]*)")/g;
+  const ARGUMENT = /(?:'([^']*)'|"([^"]*)")/g;
   const COMMAND_SEPARATOR = ' /';
   const CYRILLIC_TO_LATIN_MAP = {
     а: 'a',
@@ -84,7 +84,7 @@ function run(argv) {
   let items = [];
 
   const transliterate = (string = '') => {
-    return string.replace(/[а-яёА-ЯЁ]/g, (match) => CYRILLIC_TO_LATIN_MAP[match] || match);
+    return string.replace(/[а-яёєґїА-ЯЁЄҐЇ]/g, (match) => CYRILLIC_TO_LATIN_MAP[match] || match);
   };
 
   const toPascalCase = (string = '') => {


### PR DESCRIPTION
Do not exclude other types of quotes inside of transformation arguments.